### PR TITLE
Unautheticated resources, determined by patterns, should be distinguished by the http method.

### DIFF
--- a/app/library/application/Micro.php
+++ b/app/library/application/Micro.php
@@ -4,7 +4,7 @@
  * Small Micro application to run simple/rest based applications
  *
  * @package Application
- * @author Jete O'Keeffe 
+ * @author Jete O'Keeffe
  * @version 1.0
  * @link http://docs.phalconphp.com/en/latest/reference/micro.html
  * @example
@@ -68,7 +68,7 @@ class Micro extends \Phalcon\Mvc\Micro implements IRun {
 				throw new Exception('Bad Database Adapter');
 			}
 
-			return $connection;		
+			return $connection;
 		});
 
 		$this->setDI($di);
@@ -89,7 +89,7 @@ class Micro extends \Phalcon\Mvc\Micro implements IRun {
 		// Set dir to be used inside include file
 		$namespaces = include $file;
 
-		$loader = new \Phalcon\Loader(); 
+		$loader = new \Phalcon\Loader();
 		$loader->registerNamespaces($namespaces)->register();
 	}
 
@@ -110,8 +110,15 @@ class Micro extends \Phalcon\Mvc\Micro implements IRun {
 			foreach($routes as $obj) {
 
                 // Which pages are allowed to skip authentication
-                if (isset($obj['authentication']) && $obj['authentication'] === FALSE) {
-                    $this->_noAuthPages[] = $obj['route'];
+                if (isset($obj['authentication']) && $obj['authentication'] === false) {
+
+                    $method = strtolower($obj['method']);
+
+                    if (! isset($this->noAuthPages[$method])) {
+                        $this->noAuthPages[$method] = array();
+                    }
+
+                    $this->noAuthPages[$method][] = $obj['route'];
                 }
 
 				switch($obj['method']) {


### PR DESCRIPTION
When I was using this in my project, I came across the problem where I was patching, deleting and getting a resource that shared the same pattern in the routes config.

Whilst I want the patch and delete operations to be authenticated, I want the get operation to be unauthenticated. Because of this, if I register the GET as unauthenticated, I was experiencing the unwanted behaviour that other operations were open too.
